### PR TITLE
Close brackets after projectName

### DIFF
--- a/kickstarter.js
+++ b/kickstarter.js
@@ -72,7 +72,7 @@ async function kickstart() {
 
     ui.log.write('Setting page title to project name');
     newIndex = newIndex.replace(/{{projectName}}/g, projectName);
-    const newWebpackProdFile = webpackProdFile.replace(/{{projectName/g, projectName);
+    const newWebpackProdFile = webpackProdFile.replace(/{{projectName}}/g, projectName);
 
     ui.log.write('Writing new index.html');
     fs.writeFileSync('./index.html', newIndex, 'utf8');


### PR DESCRIPTION
It looks like the closing brackets after `projectName` are missing so the `webpack.prod.js` file still includes them after running the kickstart script. See `title` entry below:

```js
new FaviconsWebpackPlugin({
      // Your source logo
      logo: './src/assets/icon.png',
      // The prefix for all image files (might be a folder or a name)
      prefix: 'icons-[hash]/',
      // Generate a cache file with control hashes and
      // don't rebuild the favicons until those hashes change
      persistentCache: true,
      // Inject the html into the html-webpack-plugin
      inject: true,
      // favicon background color (see https://github.com/haydenbleasel/favicons#usage)
      background: '#fff',
      // favicon app title (see https://github.com/haydenbleasel/favicons#usage)
      title: 'awesome-project}}',

      // which icons should be generated (see https://github.com/haydenbleasel/favicons#usage)
      icons: {
        android: true,
        appleIcon: true,
        appleStartup: true,
        coast: false,
        favicons: true,
        firefox: true,
        opengraph: false,
        twitter: false,
        yandex: false,
        windows: false
      }
}),
```